### PR TITLE
Interactive "solo" and "mute" elements

### DIFF
--- a/TuxGuitar/share/lang/messages.properties
+++ b/TuxGuitar/share/lang/messages.properties
@@ -361,9 +361,6 @@ track.solo=Solo
 track.mute=Mute
 
 track.short-solo-mute=S-M
-track.short-solo-mute.s=(S)
-track.short-solo-mute.m=(M)
-track.short-solo-mute.none=-
 
 
 track.string.count.dialog.title=Line Count

--- a/TuxGuitar/share/lang/messages_fr.properties
+++ b/TuxGuitar/share/lang/messages_fr.properties
@@ -211,9 +211,6 @@ track.solo=Solo
 track.mute=Muette
 
 track.short-solo-mute=S-M
-track.short-solo-mute.s=(S)
-track.short-solo-mute.m=(M)
-track.short-solo-mute.none=-
 
 
 track.string.count.dialog.title=Nombre de lignes

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTable.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTable.java
@@ -71,7 +71,7 @@ public class TGTable {
 		int columnIndex = 0;
 		this.createColumnHeaderLayout(uiLayout, this.columnNumber, ++columnIndex, false, null);
 		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnNumber, this.columnSoloMute), ++columnIndex);
-		this.createColumnHeaderLayout(uiLayout, this.columnSoloMute, ++columnIndex, false, null);
+		this.createColumnHeaderLayout(uiLayout, this.columnSoloMute, ++columnIndex, false, 42f);
 		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnSoloMute, this.columnName), ++columnIndex);
 		this.createColumnHeaderLayout(uiLayout, this.columnName, ++columnIndex, false, 250f);
 		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnName, this.columnInstrument), ++columnIndex);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRow.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRow.java
@@ -7,19 +7,22 @@ import org.herac.tuxguitar.ui.event.UIMouseDoubleClickListener;
 import org.herac.tuxguitar.ui.event.UIMouseDownListener;
 import org.herac.tuxguitar.ui.event.UIMouseEvent;
 import org.herac.tuxguitar.ui.event.UIMouseUpListener;
+import org.herac.tuxguitar.ui.layout.UILayout;
+import org.herac.tuxguitar.ui.layout.UITableLayout;
 import org.herac.tuxguitar.ui.resource.UIColor;
 import org.herac.tuxguitar.ui.resource.UIPainter;
 import org.herac.tuxguitar.ui.widget.UICanvas;
+import org.herac.tuxguitar.ui.widget.UICheckBox;
 import org.herac.tuxguitar.ui.widget.UIPanel;
 
 public class TGTableRow {
 	
 	private TGTable table;
 	private UIPanel row;
-	private TGTableRowCell number;
-	private TGTableRowCell soloMute;
-	private TGTableRowCell name;
-	private TGTableRowCell instrument;
+	private TGTableRowTextCell number;
+	private TGTableRowTextCell soloMute;
+	private TGTableRowTextCell name;
+	private TGTableRowTextCell instrument;
 	private UICanvas painter;
 	
 	private UIMouseUpListener mouseUpListenerLabel;
@@ -37,7 +40,7 @@ public class TGTableRow {
 		this.init();
 	}
 	
-	public void init(){
+	private void init(){
 		UIFactory uiFactory = this.table.getUIFactory();
 		MouseListenerLabel mouseListenerLabel = new MouseListenerLabel();
 		MouseListenerCanvas mouseListenerCanvas = new MouseListenerCanvas();
@@ -45,22 +48,22 @@ public class TGTableRow {
 		this.row = uiFactory.createPanel(this.table.getRowControl(), false);
 		this.row.setLayout(new TGTableRowLayout(this));
 		
-		this.number = new TGTableRowCell(this);
+		this.number = new TGTableRowTextCell(this);
 		this.number.addMouseDownListener(mouseListenerLabel);
 		this.number.addMouseUpListener(mouseListenerLabel);
 		this.number.addMouseDoubleClickListener(mouseListenerLabel);
 		
-		this.soloMute = new TGTableRowCell(this);
+		this.soloMute = new TGTableRowTextCell(this);
 		this.soloMute.addMouseDownListener(mouseListenerLabel);
 		this.soloMute.addMouseUpListener(mouseListenerLabel);
 		this.soloMute.addMouseDoubleClickListener(mouseListenerLabel);
 		
-		this.name = new TGTableRowCell(this);
+		this.name = new TGTableRowTextCell(this);
 		this.name.addMouseDownListener(mouseListenerLabel);
 		this.name.addMouseUpListener(mouseListenerLabel);
 		this.name.addMouseDoubleClickListener(mouseListenerLabel);
 		
-		this.instrument = new TGTableRowCell(this);
+		this.instrument = new TGTableRowTextCell(this);
 		this.instrument.addMouseDownListener(mouseListenerLabel);
 		this.instrument.addMouseUpListener(mouseListenerLabel);
 		this.instrument.addMouseDoubleClickListener(mouseListenerLabel);
@@ -103,19 +106,19 @@ public class TGTableRow {
 		return this.painter;
 	}
 	
-	public TGTableRowCell getInstrument() {
+	public TGTableRowTextCell getInstrument() {
 		return this.instrument;
 	}
 	
-	public TGTableRowCell getName() {
+	public TGTableRowTextCell getName() {
 		return this.name;
 	}
 	
-	public TGTableRowCell getNumber() {
+	public TGTableRowTextCell getNumber() {
 		return this.number;
 	}
 	
-	public TGTableRowCell getSoloMute() {
+	public TGTableRowTextCell getSoloMute() {
 		return this.soloMute;
 	}
 

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRow.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRow.java
@@ -7,12 +7,9 @@ import org.herac.tuxguitar.ui.event.UIMouseDoubleClickListener;
 import org.herac.tuxguitar.ui.event.UIMouseDownListener;
 import org.herac.tuxguitar.ui.event.UIMouseEvent;
 import org.herac.tuxguitar.ui.event.UIMouseUpListener;
-import org.herac.tuxguitar.ui.layout.UILayout;
-import org.herac.tuxguitar.ui.layout.UITableLayout;
 import org.herac.tuxguitar.ui.resource.UIColor;
 import org.herac.tuxguitar.ui.resource.UIPainter;
 import org.herac.tuxguitar.ui.widget.UICanvas;
-import org.herac.tuxguitar.ui.widget.UICheckBox;
 import org.herac.tuxguitar.ui.widget.UIPanel;
 
 public class TGTableRow {

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRow.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRow.java
@@ -20,7 +20,7 @@ public class TGTableRow {
 	private TGTable table;
 	private UIPanel row;
 	private TGTableRowTextCell number;
-	private TGTableRowTextCell soloMute;
+	private TGTableRowSoloMuteCell soloMute;
 	private TGTableRowTextCell name;
 	private TGTableRowTextCell instrument;
 	private UICanvas painter;
@@ -53,7 +53,7 @@ public class TGTableRow {
 		this.number.addMouseUpListener(mouseListenerLabel);
 		this.number.addMouseDoubleClickListener(mouseListenerLabel);
 		
-		this.soloMute = new TGTableRowTextCell(this);
+		this.soloMute = new TGTableRowSoloMuteCell(this);
 		this.soloMute.addMouseDownListener(mouseListenerLabel);
 		this.soloMute.addMouseUpListener(mouseListenerLabel);
 		this.soloMute.addMouseDoubleClickListener(mouseListenerLabel);
@@ -118,7 +118,7 @@ public class TGTableRow {
 		return this.number;
 	}
 	
-	public TGTableRowTextCell getSoloMute() {
+	public TGTableRowSoloMuteCell getSoloMute() {
 		return this.soloMute;
 	}
 

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowCell.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowCell.java
@@ -6,53 +6,43 @@ import org.herac.tuxguitar.ui.event.UIMouseUpListener;
 import org.herac.tuxguitar.ui.layout.UITableLayout;
 import org.herac.tuxguitar.ui.menu.UIPopupMenu;
 import org.herac.tuxguitar.ui.resource.UIColor;
-import org.herac.tuxguitar.ui.widget.UIControl;
-import org.herac.tuxguitar.ui.widget.UILabel;
 import org.herac.tuxguitar.ui.widget.UIPanel;
 
 public class TGTableRowCell {
 	
 	private TGTableRow row;
 	private UIPanel cell;
-	private UILabel label;
+	private UITableLayout layout;
 
 	public TGTableRowCell(TGTableRow row){
 		this.row = row;
 		this.cell = this.row.getTable().getUIFactory().createPanel(this.row.getControl(), false);
-		this.label = this.row.getTable().getUIFactory().createLabel(this.cell);
-		
 		this.row.getTable().appendListeners(this.cell);
-		this.row.getTable().appendListeners(this.label);
-		
 		this.createLayout();
 	}
 	
-	public void createLayout() {
-		UITableLayout uiTableLayout = new UITableLayout();
-		uiTableLayout.set(UITableLayout.MARGIN_TOP, 2f);
-		uiTableLayout.set(UITableLayout.MARGIN_BOTTOM, 2f);
-		uiTableLayout.set(this.label, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true);
+	private void createLayout() {
+		this.layout = new UITableLayout();
+		this.layout.set(UITableLayout.MARGIN_TOP, 2f);
+		this.layout.set(UITableLayout.MARGIN_BOTTOM, 2f);
 		
-		this.cell.setLayout(uiTableLayout);
+		this.cell.setLayout(getLayout());
+	}
+	
+	public UITableLayout getLayout() {
+		return layout;
 	}
 	
 	public void setBgColor(UIColor background){
 		this.cell.setBgColor(background);
-		this.label.setBgColor(background);
 	}
 	
 	public void setFgColor(UIColor foreground){
 		this.cell.setFgColor(foreground);
-		this.label.setFgColor(foreground);
 	}
 	
 	public void setMenu(UIPopupMenu menu) {
 		this.cell.setPopupMenu(menu);
-		this.label.setPopupMenu(menu);
-	}
-	
-	public void setText(String text) {
-		this.label.setText(text);
 	}
 	
 	public void setData(String key, Object data) {
@@ -65,28 +55,22 @@ public class TGTableRowCell {
 	
 	public void addMouseDownListener(UIMouseDownListener listener) {
 		this.cell.addMouseDownListener(listener);
-		this.label.addMouseDownListener(listener);
 	}
 	
 	public void addMouseUpListener(UIMouseUpListener listener) {
 		this.cell.addMouseUpListener(listener);
-		this.label.addMouseUpListener(listener);
 	}
 	
 	public void addMouseDoubleClickListener(UIMouseDoubleClickListener listener) {
 		this.cell.addMouseDoubleClickListener(listener);
-		this.label.addMouseDoubleClickListener(listener);
 	}
 	
-	public UIControl getControl() {
+	public UIPanel getControl() {
 		return this.cell;
-	}
-	
-	public UILabel getLabel() {
-		return label;
 	}
 	
 	public void dispose(){
 		this.row.dispose();
 	}
+
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
@@ -1,5 +1,8 @@
 package org.herac.tuxguitar.app.view.component.table;
 
+import org.herac.tuxguitar.app.action.TGActionProcessorListener;
+import org.herac.tuxguitar.editor.action.track.TGChangeTrackMuteAction;
+import org.herac.tuxguitar.editor.action.track.TGChangeTrackSoloAction;
 import org.herac.tuxguitar.ui.event.UIMouseDoubleClickListener;
 import org.herac.tuxguitar.ui.event.UIMouseDownListener;
 import org.herac.tuxguitar.ui.event.UIMouseUpListener;
@@ -7,19 +10,23 @@ import org.herac.tuxguitar.ui.layout.UITableLayout;
 import org.herac.tuxguitar.ui.menu.UIPopupMenu;
 import org.herac.tuxguitar.ui.resource.UIColor;
 import org.herac.tuxguitar.ui.widget.UICheckBox;
+import org.herac.tuxguitar.util.TGContext;
 
 public class TGTableRowSoloMuteCell extends TGTableRowCell {
 
   private UICheckBox soloCheckbox;
   private UICheckBox muteCheckbox;
 
-  public TGTableRowSoloMuteCell(TGTableRow row) {
+  public TGTableRowSoloMuteCell(final TGTableRow row) {
     super(row);
     TGTable table = row.getTable();
     this.soloCheckbox = table.getUIFactory().createCheckBox(getControl());
     this.muteCheckbox = table.getUIFactory().createCheckBox(getControl());
     table.appendListeners(this.soloCheckbox);
     table.appendListeners(this.muteCheckbox);
+    TGContext context = row.getTable().getContext();
+    this.soloCheckbox.addSelectionListener(new TGActionProcessorListener(context, TGChangeTrackSoloAction.NAME));
+    this.muteCheckbox.addSelectionListener(new TGActionProcessorListener(context, TGChangeTrackMuteAction.NAME));
     getLayout().set(this.soloCheckbox, 1, 1, UITableLayout.ALIGN_CENTER, UITableLayout.ALIGN_CENTER, false, false);
     getLayout().set(this.muteCheckbox, 1, 2, UITableLayout.ALIGN_CENTER, UITableLayout.ALIGN_CENTER, false, false);
   }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
@@ -3,7 +3,6 @@ package org.herac.tuxguitar.app.view.component.table;
 import org.herac.tuxguitar.app.action.TGActionProcessorListener;
 import org.herac.tuxguitar.editor.action.track.TGChangeTrackMuteAction;
 import org.herac.tuxguitar.editor.action.track.TGChangeTrackSoloAction;
-import org.herac.tuxguitar.ui.event.UIMouseDoubleClickListener;
 import org.herac.tuxguitar.ui.event.UIMouseDownListener;
 import org.herac.tuxguitar.ui.event.UIMouseUpListener;
 import org.herac.tuxguitar.ui.layout.UITableLayout;

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
@@ -1,0 +1,76 @@
+package org.herac.tuxguitar.app.view.component.table;
+
+import org.herac.tuxguitar.ui.event.UIMouseDoubleClickListener;
+import org.herac.tuxguitar.ui.event.UIMouseDownListener;
+import org.herac.tuxguitar.ui.event.UIMouseUpListener;
+import org.herac.tuxguitar.ui.layout.UITableLayout;
+import org.herac.tuxguitar.ui.menu.UIPopupMenu;
+import org.herac.tuxguitar.ui.resource.UIColor;
+import org.herac.tuxguitar.ui.widget.UICheckBox;
+
+public class TGTableRowSoloMuteCell extends TGTableRowCell {
+
+  private UICheckBox soloCheckbox;
+  private UICheckBox muteCheckbox;
+
+  public TGTableRowSoloMuteCell(TGTableRow row) {
+    super(row);
+    TGTable table = row.getTable();
+    this.soloCheckbox = table.getUIFactory().createCheckBox(getControl());
+    this.muteCheckbox = table.getUIFactory().createCheckBox(getControl());
+    table.appendListeners(this.soloCheckbox);
+    table.appendListeners(this.muteCheckbox);
+    getLayout().set(this.soloCheckbox, 1, 1, UITableLayout.ALIGN_CENTER, UITableLayout.ALIGN_CENTER, false, false);
+    getLayout().set(this.muteCheckbox, 1, 2, UITableLayout.ALIGN_CENTER, UITableLayout.ALIGN_CENTER, false, false);
+  }
+
+  @Override
+  public void setBgColor(UIColor background) {
+    super.setBgColor(background);
+    this.soloCheckbox.setBgColor(background);
+    this.muteCheckbox.setBgColor(background);
+  }
+
+  @Override
+  public void setFgColor(UIColor foreground) {
+    super.setFgColor(foreground);
+    this.soloCheckbox.setFgColor(foreground);
+    this.muteCheckbox.setFgColor(foreground);
+  }
+
+  @Override
+  public void setMenu(UIPopupMenu menu) {
+    super.setMenu(menu);
+    this.soloCheckbox.setPopupMenu(menu);
+    this.muteCheckbox.setPopupMenu(menu);
+  }
+
+  @Override
+  public void addMouseDownListener(UIMouseDownListener listener) {
+    super.addMouseDownListener(listener);
+    this.soloCheckbox.addMouseDownListener(listener);
+    this.muteCheckbox.addMouseDownListener(listener);
+  }
+
+  @Override
+  public void addMouseUpListener(UIMouseUpListener listener) {
+    super.addMouseUpListener(listener);
+    this.soloCheckbox.addMouseUpListener(listener);
+    this.muteCheckbox.addMouseUpListener(listener);
+  }
+
+  @Override
+  public void addMouseDoubleClickListener(UIMouseDoubleClickListener listener) {
+    super.addMouseDoubleClickListener(listener);
+    this.soloCheckbox.addMouseDoubleClickListener(listener);
+    this.muteCheckbox.addMouseDoubleClickListener(listener);
+  }
+
+  public void setSolo(boolean solo) {
+    this.soloCheckbox.setSelected(solo);
+  }
+
+  public void setMute(boolean mute) {
+    this.muteCheckbox.setSelected(mute);
+  }
+}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowSoloMuteCell.java
@@ -66,13 +66,6 @@ public class TGTableRowSoloMuteCell extends TGTableRowCell {
     this.muteCheckbox.addMouseUpListener(listener);
   }
 
-  @Override
-  public void addMouseDoubleClickListener(UIMouseDoubleClickListener listener) {
-    super.addMouseDoubleClickListener(listener);
-    this.soloCheckbox.addMouseDoubleClickListener(listener);
-    this.muteCheckbox.addMouseDoubleClickListener(listener);
-  }
-
   public void setSolo(boolean solo) {
     this.soloCheckbox.setSelected(solo);
   }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowTextCell.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableRowTextCell.java
@@ -1,0 +1,66 @@
+package org.herac.tuxguitar.app.view.component.table;
+
+import org.herac.tuxguitar.ui.event.UIMouseDoubleClickListener;
+import org.herac.tuxguitar.ui.event.UIMouseDownListener;
+import org.herac.tuxguitar.ui.event.UIMouseUpListener;
+import org.herac.tuxguitar.ui.layout.UITableLayout;
+import org.herac.tuxguitar.ui.menu.UIPopupMenu;
+import org.herac.tuxguitar.ui.resource.UIColor;
+import org.herac.tuxguitar.ui.widget.UILabel;
+
+public class TGTableRowTextCell extends TGTableRowCell {
+
+  private UILabel label;
+
+  public TGTableRowTextCell(TGTableRow row) {
+    super(row);
+    TGTable table = row.getTable();
+    this.label = table.getUIFactory().createLabel(getControl());
+    table.appendListeners(this.label);
+    getLayout().set(this.label, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true);
+  }
+
+  @Override
+  public void setBgColor(UIColor background) {
+    super.setBgColor(background);
+    this.label.setBgColor(background);
+  }
+
+  @Override
+  public void setFgColor(UIColor foreground) {
+    super.setFgColor(foreground);
+    this.label.setFgColor(foreground);
+  }
+
+  @Override
+  public void setMenu(UIPopupMenu menu) {
+    super.setMenu(menu);
+    this.label.setPopupMenu(menu);
+  }
+
+  @Override
+  public void addMouseDownListener(UIMouseDownListener listener) {
+    super.addMouseDownListener(listener);
+    this.label.addMouseDownListener(listener);
+  }
+
+  @Override
+  public void addMouseUpListener(UIMouseUpListener listener) {
+    super.addMouseUpListener(listener);
+    this.label.addMouseUpListener(listener);
+  }
+
+  @Override
+  public void addMouseDoubleClickListener(UIMouseDoubleClickListener listener) {
+    super.addMouseDoubleClickListener(listener);
+    this.label.addMouseDoubleClickListener(listener);
+  }
+
+  public void setText(String text) {
+    this.label.setText(text);
+  }
+
+  public UILabel getLabel() {
+    return label;
+  }
+}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
@@ -215,16 +215,6 @@ public class TGTableViewer implements TGEventListener {
 		return new String();
 	}
 	
-	private String getSoloMute(TGTrack track){
-		if( track.isSolo() ){
-			return TuxGuitar.getProperty("track.short-solo-mute.s");
-		}
-		if( track.isMute() ){
-			return TuxGuitar.getProperty("track.short-solo-mute.m");
-		}
-		return TuxGuitar.getProperty("track.short-solo-mute.none");
-	}
-	
 	private void updateTable(){
 		if( this.update ){
 			this.updateTableMenu();
@@ -240,17 +230,16 @@ public class TGTableViewer implements TGEventListener {
 				final TGTableRow row = this.table.getRow(i);
 				if(row != null){
 					//Number
-					this.updateTableRow(row.getNumber(), track, Integer.toString(track.getNumber()));
+					this.updateTableTextRow(row.getNumber(), track, Integer.toString(track.getNumber()));
 					
 					//Solo-Mute
-					// FIXME: Change
-					this.updateTableRow(row.getSoloMute(), track, getSoloMute(track));
+					this.updateTableSoloMuteRow(row.getSoloMute(), track);
 					
 					//Name
-					this.updateTableRow(row.getName(), track, track.getName());
+					this.updateTableTextRow(row.getName(), track, track.getName());
 					
 					//Instrument
-					this.updateTableRow(row.getInstrument(), track, getInstrument(track));
+					this.updateTableTextRow(row.getInstrument(), track, getInstrument(track));
 					
 					row.setMouseUpListenerLabel(new UIMouseUpListener() {
 						public void onMouseUp(UIMouseEvent event) {
@@ -341,11 +330,21 @@ public class TGTableViewer implements TGEventListener {
 		return false;
 	}
 	
-	private void updateTableRow(TGTableRowTextCell cell, TGTrack track, String label) {
-		cell.setText(label);
+	private void updateTableRow(TGTableRowCell cell, TGTrack track) {
 		cell.setData(TGTrack.class.getName(), track);
 		cell.setMenu((UIPopupMenu) this.menu.getMenu());
 	}
+	
+	private void updateTableTextRow(TGTableRowTextCell cell, TGTrack track, String label) {
+		cell.setText(label);
+		updateTableRow(cell, track);
+	}
+  
+  private void updateTableSoloMuteRow(TGTableRowSoloMuteCell cell, TGTrack track) {
+    cell.setSolo(track.isSolo());
+    cell.setMute(track.isMute());
+    updateTableRow(cell, track);
+  }
 	
 	private void updateTableMenu() {
 		this.disposeMenu();
@@ -376,8 +375,8 @@ public class TGTableViewer implements TGEventListener {
 			TGTableRow row = this.table.getRow(i);
 			
 			row.getNumber().setText(Integer.toString(((TGTrack)row.getNumber().getData(TGTrack.class.getName())).getNumber()));
-			// FIXME: Change
-			row.getSoloMute().setText(getSoloMute((TGTrack)row.getSoloMute().getData(TGTrack.class.getName())));
+			row.getSoloMute().setSolo(((TGTrack)row.getSoloMute().getData(TGTrack.class.getName())).isSolo());
+			row.getSoloMute().setMute(((TGTrack)row.getSoloMute().getData(TGTrack.class.getName())).isMute());
 			row.getName().setText(((TGTrack)row.getName().getData(TGTrack.class.getName())).getName());
 			row.getInstrument().setText(getInstrument((TGTrack)row.getInstrument().getData(TGTrack.class.getName())));
 		}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
@@ -243,6 +243,7 @@ public class TGTableViewer implements TGEventListener {
 					this.updateTableRow(row.getNumber(), track, Integer.toString(track.getNumber()));
 					
 					//Solo-Mute
+					// FIXME: Change
 					this.updateTableRow(row.getSoloMute(), track, getSoloMute(track));
 					
 					//Name
@@ -340,7 +341,7 @@ public class TGTableViewer implements TGEventListener {
 		return false;
 	}
 	
-	private void updateTableRow(TGTableRowCell cell, TGTrack track, String label) {
+	private void updateTableRow(TGTableRowTextCell cell, TGTrack track, String label) {
 		cell.setText(label);
 		cell.setData(TGTrack.class.getName(), track);
 		cell.setMenu((UIPopupMenu) this.menu.getMenu());
@@ -375,6 +376,7 @@ public class TGTableViewer implements TGEventListener {
 			TGTableRow row = this.table.getRow(i);
 			
 			row.getNumber().setText(Integer.toString(((TGTrack)row.getNumber().getData(TGTrack.class.getName())).getNumber()));
+			// FIXME: Change
 			row.getSoloMute().setText(getSoloMute((TGTrack)row.getSoloMute().getData(TGTrack.class.getName())));
 			row.getName().setText(((TGTrack)row.getName().getData(TGTrack.class.getName())).getName());
 			row.getInstrument().setText(getInstrument((TGTrack)row.getInstrument().getData(TGTrack.class.getName())));

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
@@ -339,12 +339,12 @@ public class TGTableViewer implements TGEventListener {
 		cell.setText(label);
 		updateTableRow(cell, track);
 	}
-  
-  private void updateTableSoloMuteRow(TGTableRowSoloMuteCell cell, TGTrack track) {
-    cell.setSolo(track.isSolo());
-    cell.setMute(track.isMute());
-    updateTableRow(cell, track);
-  }
+	
+	private void updateTableSoloMuteRow(TGTableRowSoloMuteCell cell, TGTrack track) {
+		cell.setSolo(track.isSolo());
+		cell.setMute(track.isMute());
+		updateTableRow(cell, track);
+	}
 	
 	private void updateTableMenu() {
 		this.disposeMenu();


### PR DESCRIPTION
- Solo/mute in track list is now displayed as two checkboxes, whose state is synced with corresponding property
- Checking/unchecking applies the change immediately, thus eliminating the need to right-click on a track

How it looks like:
![Solo/mute checkboxes screenshot](http://pix.my/o/VVBhtK?1515431366)

Resolves https://sourceforge.net/p/tuxguitar/feature-requests/32/ 

Would be nice to show a tooltip for checkboxes, but unfortunately they are currently not supported by UI abstraction for some reason.