### PR TITLE
Make GMChannelRouter use channels sparingly

### DIFF
--- a/TuxGuitar-gm-utils/src/org/herac/tuxguitar/gm/GMChannelRouter.java
+++ b/TuxGuitar-gm-utils/src/org/herac/tuxguitar/gm/GMChannelRouter.java
@@ -60,8 +60,9 @@ public class GMChannelRouter {
 			// Add default routes
 			else {
 				List<Integer> freeChannels = getFreeChannels();
-				route.setChannel1(( freeChannels.size() > 0 ? ((Integer)freeChannels.get(0)).intValue() : GMChannelRoute.NULL_VALUE ) );
-				route.setChannel2(( freeChannels.size() > 1 ? ((Integer)freeChannels.get(1)).intValue() : route.getChannel1() ) );
+				int freeChannel = freeChannels.isEmpty() ? GMChannelRoute.NULL_VALUE : freeChannels.get(0);
+				route.setChannel1(freeChannel);
+				route.setChannel2(freeChannel);
 			}
 		}
 		


### PR DESCRIPTION
Makes `GMChannelRouter` use just one free channel for routing instead of two.
Before this fix, importing MIDI file with more than 8 channels would result in some channels being lost.

**WARNING:** While this _seems_ to work as a proper fix, there might be undiscovered side effects.
My understanding of channel routing in TuxGuitar isn't nearly enough, additional testing/insight might be needed,

Potentially resolves https://sourceforge.net/p/tuxguitar/bugs/85/